### PR TITLE
Add trigger for ImageStreamTag

### DIFF
--- a/openshift/azagent-deployment.yaml
+++ b/openshift/azagent-deployment.yaml
@@ -82,6 +82,9 @@ objects:
     namespace: "${NAMESPACE}"
     labels:
       app: azdevops-agent
+    annotations:
+      image.openshift.io/triggers: >-
+        [{"from":{"kind":"ImageStreamTag","name":"azure-devops-ocp-agent:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"azure-devops-ocp-agent\")].image"}]
   spec:
     replicas: 1 
     selector:


### PR DESCRIPTION
Hi Ben,
found that a rebuild of the azure agent image would not result in a redeploy of the agent. This seems to do the trick.

Regards,
Stephen D